### PR TITLE
Update README with link to Packagist installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Updated README with link to Packagist 
+
 ## [1.0.0] - 2020-02-25
 Initial set up.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This might be solved by using a solution similar to the middleware defined in [P
 
 ## Installation
 
-Coming soon.
+```bash
+composer require coolblue/http-client-middleware 
+```
 
 ## Usage 
 Middleware needs to comply to the interface `\Coolblue\Http\Client\MiddlewareInterface`:


### PR DESCRIPTION
At time of tagging version 1.0.0 the library was not yet registered at Packagist. This has happened now. 