### PR TITLE
Add PHP 8.0 support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php-versions }}
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: xdebug

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,13 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.3",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        colors="true"
-        failOnRisky="true"
-        failOnWarning="true"
-        verbose="true"
->
-    <testsuites>
-        <testsuite name="Http Client Middleware Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true" failOnRisky="true" failOnWarning="true" verbose="true">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Http Client Middleware Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/MiddlewareClientTest.php
+++ b/tests/MiddlewareClientTest.php
@@ -8,12 +8,15 @@ use Coolblue\Http\Client\MiddlewareClient;
 use Coolblue\Http\Client\MiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 final class MiddlewareClientTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testHandlingOfMiddlewareInCorrectOrder(): void
     {
         $order = [];


### PR DESCRIPTION
The codebase should be compatible with PHP 8.0. This change marks support for PHP 8.0 in our `composer.json` and runs our test suite on PHP 8.0. In order to do so I updated `shivammathur/setup-php` action to version 2.

In order to run our test suite against PHP 8 I needed to upgrade PHPUnit to version 9. 