### PR TITLE
Add PHP 8 support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     name: PHP ${{ matrix.php-versions }}
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           coverage: xdebug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.1.0] - 2020-11-26
+### Added
+- Support for PHP 8
+
 ### Changed
 - Updated README with link to Packagist 
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0",
+        "phpspec/prophecy": "^1.12",
+        "phpunit/phpunit": "^8.0 || ^9.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/tests/MiddlewareClientTest.php
+++ b/tests/MiddlewareClientTest.php
@@ -8,6 +8,7 @@ use Coolblue\Http\Client\MiddlewareClient;
 use Coolblue\Http\Client\MiddlewareInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophet;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -18,10 +19,12 @@ final class MiddlewareClientTest extends TestCase
     {
         $order = [];
 
-        $request = $this->prophesize(RequestInterface::class);
-        $response = $this->prophesize(ResponseInterface::class);
+        $prophet = new Prophet();
 
-        $middlewareOne = $this->prophesize(MiddlewareInterface::class);
+        $request = $prophet->prophesize(RequestInterface::class);
+        $response = $prophet->prophesize(ResponseInterface::class);
+
+        $middlewareOne = $prophet->prophesize(MiddlewareInterface::class);
         $middlewareOne->process(Argument::type(RequestInterface::class), Argument::type(ClientInterface::class))
             ->shouldBeCalled()
             ->will(function (array $arguments) use (&$order) {
@@ -32,7 +35,7 @@ final class MiddlewareClientTest extends TestCase
                 return $response;
             });
 
-        $middlewareTwo = $this->prophesize(MiddlewareInterface::class);
+        $middlewareTwo = $prophet->prophesize(MiddlewareInterface::class);
         $middlewareTwo->process(Argument::type(RequestInterface::class), Argument::type(ClientInterface::class))
             ->shouldBeCalled()
             ->will(function (array $arguments) use (&$order) {
@@ -44,7 +47,7 @@ final class MiddlewareClientTest extends TestCase
                 return $response;
             });
 
-        $client = $this->prophesize(ClientInterface::class);
+        $client = $prophet->prophesize(ClientInterface::class);
         $client->sendRequest(Argument::type(RequestInterface::class))
             ->shouldBeCalledOnce()
             ->will(function () use (&$order, $response) {


### PR DESCRIPTION
The code works as it should under PHP 8. This will mark that it works with PHP 8 in `composer.json`.

In order to ensure the code works on PHP 8 as well the inspections should also run on PHP 8. As the library runs perfectly fine on PHP 7.2 and PHP 7.3 I don't see a necessity to drop support for those versions. In order to still support PHP 8 PHPUnit needs to be updated to version 9, but that version drops support for PHP 7.2 and PHP 7.3. The solution is to require either PHPUnit 8 or PHPUnit 9.

This left an issue with the usage of Prophecy as Prophecy is deprecated in PHPUnit 9. As the test suite is so small the solution for this project has been to add `phpspec/prophecy` as a direct development dependency and using Prophecy direct instead of via `\PHPUnit\Framework\TestCase::prophesize()`.

- Update PHP requirement to `^7.2 || ^8.0`
- Update `shivammathur/setup-php` to version 2
- Set Github Actions to be run for PHP versions 7.2, 7.3, 7.4 and 8.0
- Update PHPUnit requirement to `^8.0 || ^9.0`
- Add `phpspec/prophecy` as a direct development dependency
- Replace calls to `\PHPUnit\Framework\TestCase::prophesize()` with calls to `\Prophecy\Prophet::prophesize()`