### PR TITLE
Add PHP 8.1 nightly to inspections

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,9 +5,11 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{matrix.experimental}}
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        experimental: [false, false, false, false, true]
     name: PHP ${{ matrix.php-versions }}
 
     steps:


### PR DESCRIPTION
Add PHP 8.1 to versions to inspect on pull requests. This version is still in development, which is why it is marked as experimental.