### PR TITLE
Add PHP 8.1 to inspections

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }}
 
     steps:


### PR DESCRIPTION
Add PHP 8.1 to the list of versions to run inspections on.

Fixes #14 