### PR TITLE
Support for PHP 8.3

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- Support for PHP versions < 8.0
+
 ## [1.1.0] - 2020-11-26
 ### Added
 - Support for PHP 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2023-12-20
 ### Removed
 - Support for PHP versions < 8.0
+
+### Changed
+- Dependency on `psr/http-message` now is `^1.0 || ^2.0`
 
 ## [1.1.0] - 2020-11-26
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,13 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0"
     },
     "require-dev": {
-        "phpspec/prophecy": "^1.12",
-        "phpunit/phpunit": "^8.0 || ^9.0",
+        "phpspec/prophecy": "^1.17",
+        "phpunit/phpunit": "^9.0 || ^10.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "^8.0",
         "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpspec/prophecy": "^1.17",


### PR DESCRIPTION
PHP 8.3 has just been released - https://www.php.net/releases/8.3/en.php. Therefore this introduces inspections for PHP 8.3.

At the same time is PHP 8.0 almost end of life - https://www.php.net/supported-versions.php. Therefore we should be able to drop support for < 8.0.

PS. Inspections are currently failing due to a constrain violation caused by Prophecy. Once Prophecy updates their code the inspections should pass.