### PR TITLE
Run inspections on PHP 8.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }}
 
     steps:


### PR DESCRIPTION
Now that PHP 8.4 is officially released we should run the inspections on that version as well.